### PR TITLE
fix: use context.joker_main instead of 'not context.before and not context.after'

### DIFF
--- a/mod/FusionJokers.lua
+++ b/mod/FusionJokers.lua
@@ -614,7 +614,7 @@ function SMODS.INIT.FusionJokers()
 	end
 
 	function SMODS.Jokers.j_big_bang.calculate(card, context)
-		if context.cardarea == G.jokers and not context.after and not context.before and context.scoring_name then
+		if context.cardarea == G.jokers and context.joker_main and context.scoring_name then
 			local mult_val = 1 + card.ability.extra.Xmult * (G.GAME.hands[context.scoring_name].level + G.GAME.hands[context.scoring_name].played)
 			return {
 				message = localize{type='variable',key='a_xmult',vars={mult_val}},
@@ -691,7 +691,7 @@ function SMODS.INIT.FusionJokers()
              end)}))
 		end
 
-		if context.cardarea == G.jokers and card.ability.mult > 0 and not context.after and not context.before then
+		if context.cardarea == G.jokers and card.ability.mult > 0 and context.joker_main then
 			return {
 				message = localize{type='variable',key='a_mult',vars={card.ability.mult}},
 				mult_mod = card.ability.mult
@@ -788,7 +788,7 @@ function SMODS.INIT.FusionJokers()
 			
 		end
 
-		if context.cardarea == G.jokers and not context.after and not context.before then
+		if context.cardarea == G.jokers and context.joker_main then
 			if card.ability.extra.side == "mult" then
 				return {
 					message = localize{type='variable',key='a_mult',vars={card.ability.extra.mult}},
@@ -894,7 +894,7 @@ function SMODS.INIT.FusionJokers()
 			end
 		end
 
-		if context.cardarea == G.jokers and not context.after and not context.before then
+		if context.cardarea == G.jokers and context.joker_main then
 			local x = 0
 			for i = 1, #G.jokers.cards do
 				if G.jokers.cards[i].ability.set == 'Joker' then x = x + 1 end
@@ -991,7 +991,7 @@ function SMODS.INIT.FusionJokers()
 			end
 		end
 
-		if context.cardarea == G.jokers and not context.after and not context.before then
+		if context.cardarea == G.jokers and context.joker_main then
 			local mult = card.ability.mult * G.GAME.current_round.discards_left
 			return {
 				message = localize{type='variable',key='a_mult',vars={mult}},
@@ -1084,7 +1084,7 @@ function SMODS.INIT.FusionJokers()
 			end
 		end
 
-		if context.cardarea == G.jokers and not context.before and not context.after then
+		if context.cardarea == G.jokers and context.joker_main then
 			return {
 				message = localize{type='variable',key='a_xmult',vars={card.ability.extra.total}},
 				Xmult_mod = card.ability.extra.total


### PR DESCRIPTION
This avoids issues where the cards continuously trigger on recent versions of SMODS.